### PR TITLE
Fix tar invocation (flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ First, get the page and RSS feed templates:
 
 ```shell
 curl -L https://github.com/hoffa/pt/archive/master.tar.gz \
-  | tar xz --strip-components=1 pt-master/templates
+  | tar zxf- --strip-components=1 pt-master/templates
 ```
 
 Create the index page as `index.md`:


### PR DESCRIPTION
Not all tar implementations detect (or assume) stdin as their default read source (ex. BSDs, Solaris, etc.).  In fact, most assume a tape device (ex. `/dev/sa0`), so `-f -` must be used.

The author prefers non-hyphenated flags, so for this to work properly, the flags must be in the correct order, ex. `zxf-`.